### PR TITLE
add a more advanced Finder configuration support

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -18,6 +18,7 @@ use StyleCI\Config\Exceptions\InvalidPresetException;
  * This is the config class.
  *
  * @author Graham Campbell <graham@mineuk.com>
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class Config
 {
@@ -384,6 +385,13 @@ class Config
     protected $excluded = [];
 
     /**
+     * The configuration of the Finder.
+     *
+     * @var \StyleCI\Config\FinderConfig|null
+     */
+    protected $finderConfig;
+
+    /**
      * Set the enabled fixers to a preset.
      *
      * It should be noted that this will totally discard the list of already
@@ -516,5 +524,29 @@ class Config
     public function getExcluded()
     {
         return $this->excluded;
+    }
+
+    /**
+     * Set the Finder configuration.
+     *
+     * @param \StyleCI\Config\FinderConfig $config
+     *
+     * @return \StyleCI\Config\Config
+     */
+    public function finderConfig(FinderConfig $config)
+    {
+        $this->finderConfig = $config;
+
+        return $this;
+    }
+
+    /**
+     * Get Finder configuration.
+     *
+     * @return \StyleCI\Config\FinderConfig|null
+     */
+    public function getFinderConfig()
+    {
+        return $this->finderConfig;
     }
 }

--- a/src/Exceptions/InvalidFinderDirectoryException.php
+++ b/src/Exceptions/InvalidFinderDirectoryException.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of StyleCI Config.
+ *
+ * (c) Graham Campbell <graham@mineuk.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\Config\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * This is the invalid finder directory exception class.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class InvalidFinderDirectoryException extends InvalidArgumentException implements ConfigExceptionInterface
+{
+    /**
+     * The invalid directory.
+     *
+     * @var mixed
+     */
+    protected $directory;
+
+    /**
+     * Create a new invalid finder directory exception instance.
+     *
+     * @param mixed $directory
+     *
+     * @return void
+     */
+    public function __construct($directory)
+    {
+        $this->directory = $directory;
+
+        if (is_string($directory)) {
+            parent::__construct("The provided finder directory '$directory' was not valid.");
+        } else {
+            parent::__construct('The provided finder directory was not valid.');
+        }
+    }
+
+    /**
+     * Get the invalid directory.
+     *
+     * @return mixed
+     */
+    public function getDirectory()
+    {
+        return $this->directory;
+    }
+}

--- a/src/Exceptions/InvalidFinderTypeException.php
+++ b/src/Exceptions/InvalidFinderTypeException.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of StyleCI Config.
+ *
+ * (c) Graham Campbell <graham@mineuk.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\Config\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * This is the invalid finder type exception class.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class InvalidFinderTypeException extends InvalidArgumentException implements ConfigExceptionInterface
+{
+    /**
+     * The invalid type.
+     *
+     * @var mixed
+     */
+    protected $type;
+
+    /**
+     * Create a new invalid finder type exception instance.
+     *
+     * @param mixed $type
+     *
+     * @return void
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+
+        if (is_string($type)) {
+            parent::__construct("The provided finder type '$type' was not valid.");
+        } else {
+            parent::__construct('The provided finder type was not valid.');
+        }
+    }
+
+    /**
+     * Get the invalid type.
+     *
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/src/FinderConfig.php
+++ b/src/FinderConfig.php
@@ -1,0 +1,397 @@
+<?php
+
+/*
+ * This file is part of StyleCI Config.
+ *
+ * (c) Graham Campbell <graham@mineuk.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\Config;
+
+use StyleCI\Config\Exceptions\InvalidFinderDirectoryException;
+
+/**
+ * This is the finder configuration class.
+ *
+ * Each configuration is used for a "test", the Finder uses
+ * the tests to determine if the matched file fulfills the tests condition.
+ *
+ * Note that setter methods will overwrite the existing configuration
+ * of the related type. So calling in() multiple times will overwrite
+ * the previously set values of "in".
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class FinderConfig
+{
+    /**
+     * The the files and directories which match the defined rules.
+     *
+     * Directories are relative to the root-directory of the "project".
+     *
+     * @var string[]
+     */
+    protected $in = [];
+
+    /**
+     * The directories which are excluded.
+     *
+     * @var string[]
+     */
+    protected $exclude = [];
+
+    /**
+     * The rules that files must match.
+     *
+     * @var string[]
+     */
+    protected $name = [];
+
+    /**
+     * The rules that files must not match.
+     *
+     * @var string[]
+     */
+    protected $notName = [];
+
+    /**
+     * The tests that file contents must match.
+     *
+     * @var string[]
+     */
+    protected $contains = [];
+
+    /**
+     * The tests that file contents must not match.
+     *
+     * @var string[]
+     */
+    protected $notContains = [];
+
+    /**
+     * The rules that filenames must match.
+     *
+     * @var string[]
+     */
+    protected $path = [];
+
+    /**
+     * The rules that filenames must not match.
+     *
+     * @var string[]
+     */
+    protected $notPath = [];
+
+    /**
+     * The tests for the directory depth.
+     *
+     * Eg:
+     *
+     *    '> 1' // the Finder will start matching at level 1.
+     *    '< 3' // the Finder will descend at most 3 levels of directories below the starting point.
+     *
+     * @var string[]
+     */
+    protected $depth;
+
+    /**
+     * The tests for file dates (last modified).
+     *
+     * The date must be something that strtotime() is able to parse:
+     *
+     *   'since yesterday'
+     *   'until 2 days ago'
+     *   '> now - 2 hours'
+     *   '>= 2005-10-15'
+     *
+     * @var string[]
+     */
+    protected $date = [];
+
+    /**
+     * Set the files and directories which match the defined rules.
+     *
+     * @param string[]|string $dirs
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function in($dirs)
+    {
+        $dirs = array_map(
+            function ($directory) {
+                if (!is_string($directory) && !is_numeric($directory)) {
+                    throw new InvalidFinderDirectoryException($directory);
+                }
+
+                $directory = trim($directory, '/');
+
+                // Detect for directory path traversal.
+                if ($directory === '..' || false !== strpos($directory, '../') || false !== strpos($directory, '/..')) {
+                    throw new InvalidFinderDirectoryException($directory);
+                }
+
+                return $directory;
+            },
+            (array) $dirs
+        );
+
+        $this->in = $dirs;
+
+        return $this;
+    }
+
+    /**
+     * Set which directories are excluded.
+     *
+     * @param string[]|string $dirs
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function exclude($dirs)
+    {
+        $this->exclude = (array) $dirs;
+
+        return $this;
+    }
+
+    /**
+     * Set the rules that files must match.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function name($patters)
+    {
+        $this->name = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set the rules that files must not match.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function notName($patters)
+    {
+        $this->notName = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set tests that file contents must match.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function contains($patters)
+    {
+        $this->contains = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set tests that file contents must not match.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function notContains($patters)
+    {
+        $this->notContains = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set rules that filenames must match.
+     *
+     * You can use patterns (delimited with / sign) or simple strings.
+     *
+     *  'some/special/dir'
+     *  '/some\/special\/dir/' // same as above
+     *
+     * Use only / as dirname separator.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function path($patters)
+    {
+        $this->path = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set rules that filenames must not match.
+     *
+     * You can use patterns (delimited with / sign) or simple strings.
+     *
+     *  'some/special/dir'
+     *  '/some\/special\/dir/' // same as above
+     *
+     * Use only / as dirname separator.
+     *
+     * @param string[]|string $patters
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function notPath($patters)
+    {
+        $this->notPath = (array) $patters;
+
+        return $this;
+    }
+
+    /**
+     * Set tests for the directory depth.
+     *
+     * Usage:
+     *
+     *   '> 1' // the Finder will start matching at level 1.
+     *   '< 3' // the Finder will descend at most 3 levels of directories below the starting point.
+     *
+     * @param string[]|string $depth
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function depth($depth)
+    {
+        $this->depth = $depth;
+
+        return $this;
+    }
+
+    /**
+     * Set tests for file dates (last modified).
+     *
+     * The date must be something that strtotime() is able to parse:
+     *
+     *   'since yesterday'
+     *   'until 2 days ago'
+     *   '> now - 2 hours'
+     *   '>= 2005-10-15'
+     *
+     * @param string[]|string $date
+     *
+     * @return \StyleCI\Config\FinderConfig
+     */
+    public function date($date)
+    {
+        $this->date = (array) $date;
+
+        return $this;
+    }
+
+    /**
+     * Get the files and directories which match the defined rules.
+     *
+     * @return string[]
+     */
+    public function getIn()
+    {
+        return $this->in;
+    }
+
+    /**
+     * Get the directories which are excluded.
+     *
+     * @return string[]
+     */
+    public function getExclude()
+    {
+        return $this->exclude;
+    }
+
+    /**
+     * Get the rules that files must match.
+     *
+     * @return string[]
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the rules that files must not match.
+     *
+     * @return string[]
+     */
+    public function getNotName()
+    {
+        return $this->notName;
+    }
+
+    /**
+     * Get rhe tests that file contents must match.
+     *
+     * @return string[]
+     */
+    public function getContains()
+    {
+        return $this->contains;
+    }
+
+    /**
+     * Get the tests that file contents must not match.
+     *
+     * @return string[]
+     */
+    public function getNotContains()
+    {
+        return $this->notContains;
+    }
+
+    /**
+     * Get the rules that filenames must match.
+     *
+     * @return string[]
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the rules that filenames must not match.
+     *
+     * @return string[]
+     */
+    public function getNotPath()
+    {
+        return $this->notPath;
+    }
+
+    /**
+     * Get the tests for the directory depth.
+     *
+     * @return string[]
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     * Get the tests for file dates (last modified).
+     *
+     * @return string[]
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+}

--- a/tests/ConfigFactoryTest.php
+++ b/tests/ConfigFactoryTest.php
@@ -13,6 +13,7 @@ namespace StyleCI\Tests\Config;
 
 use GrahamCampbell\TestBench\AbstractTestCase;
 use StyleCI\Config\ConfigFactory;
+use StyleCI\Config\FinderConfig;
 
 /**
  * This is the config factory test case class.
@@ -58,6 +59,28 @@ class ConfigFactoryTest extends AbstractTestCase
         $this->assertNotContains('psr0', $config->getFixers());
         $this->assertSame(['php', 'php.stub'], $config->getExtensions());
         $this->assertSame(['foo', 'bar'], $config->getExcluded());
+    }
+
+    public function testMakeConfigFromYmlWithFinder()
+    {
+        $config = (new ConfigFactory())->makeFromYaml(file_get_contents(__DIR__.'/stubs/finder.yml'));
+
+        $this->assertInstanceOf(FinderConfig::class, $config->getFinderConfig());
+
+        $this->assertEquals(['src'], $config->getFinderConfig()->getIn());
+        $this->assertEquals(['*.php', '*.php.stub'], $config->getFinderConfig()->getName());
+        $this->assertEquals(['foo', 'bar'], $config->getFinderConfig()->getExclude());
+        $this->assertEquals(['Kernel'], $config->getFinderConfig()->getNotContains());
+        $this->assertEquals(['Fixtures/*'], $config->getFinderConfig()->getNotPath());
+    }
+
+    /**
+     * @expectedException \StyleCI\Config\Exceptions\InvalidFinderTypeException
+     * @expectedExceptionMessage The provided finder type 'filter' was not valid.
+     */
+    public function testMakeConfigFromYmlWithInvalidFinderType()
+    {
+        (new ConfigFactory())->makeFromYaml(file_get_contents(__DIR__.'/stubs/invalid_finder_type.yml'));
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -14,6 +14,7 @@ namespace StyleCI\Tests\Config;
 use Exception;
 use GrahamCampbell\TestBench\AbstractTestCase;
 use StyleCI\Config\Config;
+use StyleCI\Config\FinderConfig;
 
 /**
  * This is the config test case class.
@@ -120,5 +121,18 @@ class ConfigTest extends AbstractTestCase
 
         $config->disable('psr0');
         $this->assertNotContains('psr0', $config->getFixers());
+    }
+
+    public function testFinderConfig()
+    {
+        $finderConfig = new FinderConfig();
+
+        $config = new Config();
+
+        $this->assertNull($config->getFinderConfig());
+
+        $config->finderConfig($finderConfig);
+
+        $this->assertSame($finderConfig, $config->getFinderConfig());
     }
 }

--- a/tests/FinderConfigTest.php
+++ b/tests/FinderConfigTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of StyleCI Config.
+ *
+ * (c) Graham Campbell <graham@mineuk.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\Tests\Config;
+
+use stdClass;
+use StyleCI\Config\Exceptions\InvalidFinderDirectoryException;
+use StyleCI\Config\FinderConfig;
+
+/**
+ * This is the finder config test case class.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class FinderConfigTest extends AbstractTestCase
+{
+    public function testIn()
+    {
+        $in = (new FinderConfig())->in(['src/', '/tests/', 'lib/my'])->getIn();
+
+        $this->assertEquals(['src', 'tests', 'lib/my'], $in);
+    }
+
+    public function testExclude()
+    {
+        $exclude = (new FinderConfig())->exclude(['fixtures', 'spec'])->getExclude();
+
+        $this->assertEquals(['fixtures', 'spec'], $exclude);
+    }
+
+    public function testName()
+    {
+        $name = (new FinderConfig())->name(['*.php', '*.php.stub'])->getName();
+
+        $this->assertEquals(['*.php', '*.php.stub'], $name);
+    }
+
+    public function testNotName()
+    {
+        $notName = (new FinderConfig())->notName(['*.blade.php', '*.html.php'])->getNotName();
+
+        $this->assertEquals(['*.blade.php', '*.html.php'], $notName);
+    }
+
+    public function testContains()
+    {
+        $contains = (new FinderConfig())->contains('<'.'?php')->getContains();
+
+        $this->assertEquals(['<'.'?php'], $contains);
+    }
+
+    public function testNotContains()
+    {
+        $notContains = (new FinderConfig())->notContains('Kernel')->getNotContains();
+
+        $this->assertEquals(['Kernel'], $notContains);
+    }
+
+    public function testPath()
+    {
+        $path = (new FinderConfig())->path(['foo'])->getPath();
+
+        $this->assertEquals(['foo'], $path);
+    }
+
+    public function testNotPath()
+    {
+        $notPath = (new FinderConfig())->notpath(['bar'])->getNotPath();
+
+        $this->assertEquals(['bar'], $notPath);
+    }
+
+    public function testDepth()
+    {
+        $depth = (new FinderConfig())->depth(['> 5'])->getDepth();
+
+        $this->assertEquals(['> 5'], $depth);
+    }
+
+    public function testDate()
+    {
+        $date = (new FinderConfig())->date(['> now'])->getDate();
+
+        $this->assertEquals(['> now'], $date);
+    }
+
+    /**
+     * @dataProvider provideValidDirectories
+     */
+    public function testInWithValidDirectories($directory)
+    {
+        $in = (new FinderConfig())->in($directory)->getIn();
+
+        $this->assertEquals((array) $directory, $in);
+    }
+
+    /**
+     * @dataProvider provideInvalidDirectoriesStrings
+     */
+    public function testInWithInvalidDirectoryString($directory)
+    {
+        $directoryDisplay = trim($directory, '/');
+        $this->setExpectedException(InvalidFinderDirectoryException::class, "The provided finder directory '$directoryDisplay' was not valid.");
+
+        (new FinderConfig())->in($directory);
+    }
+
+    /**
+     * @dataProvider provideInvalidDirectoriesValues
+     */
+    public function testInWithInvalidDirectoryValue($directory)
+    {
+        $this->setExpectedException(InvalidFinderDirectoryException::class, 'The provided finder directory was not valid.');
+
+        (new FinderConfig())->in([$directory]);
+    }
+
+    public static function provideValidDirectories()
+    {
+        return [
+            ['src'],
+            ['tests'],
+            ['foo bar'],
+            ['f2a2'],
+            ['foo-bar'],
+            [429242],
+            [24.10],
+            [['src']],
+        ];
+    }
+
+    public static function provideInvalidDirectoriesStrings()
+    {
+        return [
+            ['../src'],
+            ['src/../'],
+            ['../'],
+            ['/../'],
+            ['/..'],
+        ];
+    }
+
+    public static function provideInvalidDirectoriesValues()
+    {
+        return [
+            [[]],
+            [null],
+            [false],
+            [new stdClass()],
+        ];
+    }
+}

--- a/tests/stubs/finder.yml
+++ b/tests/stubs/finder.yml
@@ -1,0 +1,20 @@
+preset: psr1
+
+enabled:
+  - phpdoc_no_package
+
+disabled: psr0
+
+finder:
+    in:
+        - src/
+    name:
+        - '*.php'
+        - '*.php.stub'
+    exclude:
+      - foo
+      - bar
+    not_contains:
+        - Kernel
+    not-path:
+        - 'Fixtures/*'

--- a/tests/stubs/invalid_finder_type.yml
+++ b/tests/stubs/invalid_finder_type.yml
@@ -1,0 +1,12 @@
+preset: psr1
+
+enabled:
+  - phpdoc_no_package
+
+disabled: psr0
+
+finder:
+    in:
+        - src/
+    filter:
+        - Kernel


### PR DESCRIPTION
This a Proof of concept to introduce a more advanced Configuration for the Finder.

Basically to use the finder you use the following configuration:

``` yaml
finder:
    in: [src, tests]
    exclude:
        - fixtures
        - stubs
    not_name:
        - ".blade.php"
    not_contains:
        - "Kernel"
```

Tests are missing and PHPDoc is incomplete, as I would to have some early feedback first ;)

Related to https://github.com/StyleCI/StyleCI/issues/270
