### PR TITLE
Restored class_definition

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -285,6 +285,7 @@ class Config
         'array_element_white_space_after_comma',
         'blankline_after_open_tag',
         'braces',
+        'class_definition',
         'concat_without_spaces',
         'double_arrow_multiline_whitespaces',
         'duplicate_semicolon',


### PR DESCRIPTION
Once https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1588 is resolved, this can be merged.

---

This reverts commit 06ef89be6eec31c0e2dc0ea66de01a709febbf24.
